### PR TITLE
Send id token in request plus more validation

### DIFF
--- a/src/payload.ts
+++ b/src/payload.ts
@@ -1,0 +1,52 @@
+import { RequestHandler, StatusError } from "itty-router";
+import { CFArgs } from "./router";
+import { AuthenticatedRequest, CertificateSignerPayload } from "./types";
+import { parseKey } from "sshpk";
+import { seconds } from "itty-time";
+import { verifyJWT } from "./verify";
+import { JWSInvalid, JWTInvalid } from "jose/errors";
+
+export const withPayload: RequestHandler<AuthenticatedRequest, CFArgs> = async (request: AuthenticatedRequest, env: Env, ctx: ExecutionContext) => {
+    try {
+        const payload = await request.json<CertificateSignerPayload>()
+
+        // if an identity was provided, validate this
+        if (payload.identity !== undefined) {
+            console.log("Request included an identity token")
+            const identity = await verifyJWT(payload.identity)
+
+            // make sure subjects match
+            if (identity.payload.sub !== request.sub) {
+                console.warn("Possible token substitution as subjects for authentication and identity tokens did not match")
+                throw new StatusError(401)
+            }
+
+            // warn if both were undefined
+            if (identity.payload.sub === undefined && request.sub === undefined) {
+                console.warn("sub claim was missing on tokens")
+            }
+        }
+
+        // parse provided public key
+        request.public_key = parseKey(atob(payload.public_key))
+
+        // lifetime defaults to env.SSH_CERTIFICATE_LIFETIME if not set
+        request.lifetime = payload.lifetime !== undefined ? payload.lifetime : seconds(env.SSH_CERTIFICATE_LIFETIME)
+
+        // set optional extensions list
+        request.extensions = payload.extensions
+    } catch (err) {
+        if (err instanceof JWSInvalid) {
+            console.warn("the identity token was invalid")
+            throw new StatusError(400)
+        } else if (err instanceof JWTInvalid) {
+            console.warn("the identity token failed verification")
+            throw new StatusError(401)
+        } else if (err instanceof StatusError) {
+            throw err
+        }
+
+        console.log(err)
+        throw new StatusError(503)
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,24 @@
+import { env } from "cloudflare:workers"
+import { IRequestStrict } from "itty-router"
 import { JWTPayload } from "jose"
+import { Key } from "sshpk"
 
+// this is our custom request type for our router
+export type AuthenticatedRequest = {
+    email: string
+    sub?: string
+    public_key: Key
+    identity?: JWTPayload
+    principals?: string[]
+    extensions?: typeof env.SSH_CERTIFICATE_EXTENSIONS
+	lifetime: number
+} & IRequestStrict
+
+// this is the JSON payload of a certificate request
 export type CertificateSignerPayload = {
     public_key: string
-    extensions?: string[]
+    identity?: string
+    extensions?: typeof env.SSH_CERTIFICATE_EXTENSIONS
 	lifetime?: number
 }
 
@@ -10,7 +26,13 @@ export type CertificateSignerResponse = {
     certificate: string
 }
 
+// this is the expected JWT payload for a certificate request
 export type CertificateRequestJWTPayload = {
     email?: string
-    principals?: string[]
 } & JWTPayload
+
+export type SSHExtension = {
+    critical: boolean;
+    name: string;
+    data: Buffer<ArrayBuffer>
+}


### PR DESCRIPTION
This PR has the client send the users ID token as part of the request to the CA so additional claims can be used in future, such as additional principals etc

In addition, more stringent validation of requests getting to the CA plus some extra logging was implemented.