### PR TITLE
Protect config by not allowing direct access and add locking

### DIFF
--- a/client/internal/pkg/cmd/cmd.go
+++ b/client/internal/pkg/cmd/cmd.go
@@ -13,7 +13,7 @@ import (
 type rootCommand struct {
 	configFile string
 
-	config *config.ClientConfig
+	config *config.Config
 
 	*simplecommand.Command
 }

--- a/client/internal/pkg/cmd/generate.go
+++ b/client/internal/pkg/cmd/generate.go
@@ -14,7 +14,7 @@ import (
 type generateCommand struct {
 	force bool
 
-	config *config.ClientConfig
+	config *config.Config
 
 	*simplecommand.Command
 }

--- a/client/internal/pkg/cmd/show.go
+++ b/client/internal/pkg/cmd/show.go
@@ -13,7 +13,7 @@ type showCommand struct {
 	private     bool
 	certificate bool
 
-	config *config.ClientConfig
+	config *config.Config
 
 	*simplecommand.Command
 }
@@ -64,8 +64,11 @@ func (c *showCommand) Run(ctx context.Context, cd *simplecobra.Commandeer, args 
 
 	fmt.Printf("SSH Public Key: %s", pemBytes)
 
-	if c.certificate && c.config.Ssh.Certificate != nil {
-		fmt.Printf("SSH Certificate: %s", c.config.Ssh.Certificate)
+	if c.certificate {
+		certBytes, err := c.config.GetCertificateBytes()
+		if err == nil {
+			fmt.Printf("SSH Certificate: %s", certBytes)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR ensures config data is not directly accessible by adding a `*config.Config` type that contains the `config.ClientConfig` struct.

All access is via methods on `*config.Config`.

In addition, locking has been added to `*config.Config` in case the GUI allows concurrent access at times (which should not be the case).