### PR TITLE
Ensure CLI and GUI config locations are consistent

### DIFF
--- a/client/internal/pkg/cmd/cmd.go
+++ b/client/internal/pkg/cmd/cmd.go
@@ -23,21 +23,19 @@ var (
 	ErrNoPrivateKey = errors.New("no private key found, please run \"ssh-ca-client generate\"")
 )
 
-const ConfigDirName = ".serverless-ssh-ca"
-
 func (c *rootCommand) Init(cd *simplecobra.Commandeer) error {
 	if err := c.Command.Init(cd); err != nil {
 		return err
 	}
 
-	home, err := os.UserHomeDir()
+	user, system, err := configDirs()
 	if err != nil {
 		return err
 	}
 
 	cmd := cd.CobraCommand
-	cmd.PersistentFlags().StringVar(&c.systemConfigFile, "config", filepath.Join(home, ConfigDirName, "config.yml"), "Path to configuration file")
-	cmd.PersistentFlags().StringVar(&c.userConfigFile, "user", filepath.Join(home, ConfigDirName, "user.yml"), "Path to user configuration file")
+	cmd.PersistentFlags().StringVar(&c.systemConfigFile, "config", filepath.Join(system, "config.yml"), "Path to configuration file")
+	cmd.PersistentFlags().StringVar(&c.userConfigFile, "user", filepath.Join(user, "user.yml"), "Path to user configuration file")
 
 	return nil
 }

--- a/client/internal/pkg/cmd/config_others.go
+++ b/client/internal/pkg/cmd/config_others.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const appName = "serverless-ssh-ca"
+
+func configDirs() (user, system string, err error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", "", err
+	}
+
+	return filepath.Join(dir, appName), filepath.Join("/etc", appName), nil
+}

--- a/client/internal/pkg/cmd/config_windows.go
+++ b/client/internal/pkg/cmd/config_windows.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const appName = "Serverless SSH CA Client"
+
+func configDirs() (user, system string, err error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", "", err
+	}
+
+	return filepath.Join(dir, appName), filepath.Join(os.Getenv("ProgramData"), appName), nil
+}

--- a/client/internal/pkg/cmd/tray_windows.go
+++ b/client/internal/pkg/cmd/tray_windows.go
@@ -24,17 +24,6 @@ import (
 //go:embed icons
 var resources embed.FS
 
-const appName = "Serverless SSH CA Client"
-
-func configDirs() (user, system string, err error) {
-	dir, err := os.UserConfigDir()
-	if err != nil {
-		return "", "", err
-	}
-
-	return filepath.Join(dir, appName), filepath.Join(os.Getenv("ProgramData"), appName), nil
-}
-
 func runInstall() error {
 	return eventlog.InstallAsEventCreate("Serverless SSH CA Client", eventlog.Error|eventlog.Warning|eventlog.Info)
 }


### PR DESCRIPTION
With recent change to the Windows GUI, the default config file locations for the CLI and GUI diverged.

This PR resolves this.