### PR TITLE
Replace any spaces with underscores in provided principals

### DIFF
--- a/src/payload.ts
+++ b/src/payload.ts
@@ -34,6 +34,11 @@ export const withPayload: RequestHandler<AuthenticatedRequest, CFArgs> = async (
                     // add to request making sure its as string[]
                     request.principals = typeof p === "string" ? [p] : p
 
+                    // replace any  spaces with underscores
+                    request.principals.forEach((value, index, array) => {
+                        array[index] = value.replaceAll(" ", "_")
+                    })
+
                     console.log(`Identity token included the following principals: ${request.principals.join(", ")}`)
                 } else {
                     console.log("No additional principals included in identity token")


### PR DESCRIPTION
To avoid having spaces in the principals on the certificate if (for example) group names had spaces in them, these are replaced with underscores.