### PR TITLE
Various fixes and hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ npm install
     "JWT_SSH_CERTIFICATE_PRINCIPALS_CLAIM": "groups",
     // The lifetime of the issued SSH certificates
     "SSH_CERTIFICATE_LIFETIME": "24 hours",
-    // A comma seperated list of additional principals to add to the certificate
-    "SSH_CERTIFICATE_PRINCIPALS": "ssh-admin",
+    // A comma seperated list of additional principals to add to all issued user certificates
+    "SSH_CERTIFICATE_PRINCIPALS": "",
     // Whether to add the users own name as a valid principal
-    "SSH_CERTIFICATE_INCLUDE_USER": "false",
+    "SSH_CERTIFICATE_INCLUDE_SELF": "false",
     // The list of SSH extensions to add to the certificate as a comma seperated list
     "SSH_CERTIFICATE_EXTENSIONS": "permit-X11-forwarding,permit-agent-forwarding,permit-port-forwarding,permit-pty,permit-user-rc",
     // A comma seperated list of users who are permitted to request SSH host certificates based on the email claim from the OIDC IdP

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 				"description": "The lifetime of the issued SSH certificates in human readable form (ie '24 hours'), although the client may request a shorter duration"
 			},
 			"SSH_CERTIFICATE_PRINCIPALS": {
-				"description": "A comma seperated list of additional principals to add to the SSH certificate"
+				"description": "A comma seperated list of additional principals to add to all issued user certificates"
 			},
 			"SSH_CERTIFICATE_INCLUDE_SELF": {
 				"description": "Whether to add the users own name as a valid principal (based on the part before the @ symbol in the JWT email claim)"

--- a/src/api/v3/index.ts
+++ b/src/api/v3/index.ts
@@ -33,7 +33,6 @@ import {
 import {
 	CertificateType,
 	getRevocationList,
-	isRevoked,
 	recordCertificate,
 	RevocationStatus,
 	revocationStatus,
@@ -63,7 +62,7 @@ class CaPublicKeyEndpoint extends OpenAPIRoute {
 		try {
 			const pub = await getPublic()
 
-			return c.text(`${pub}\n`)
+			return c.text(`${pub.toString("ssh").trim()}\n`)
 		} catch (err) {
 			switch (true) {
 				case (err instanceof KeyParseError):
@@ -294,12 +293,6 @@ class HostCertificateRenewEndpoint extends OpenAPIRoute {
 				"serial", serial,
 			),
 		)
-
-		// ensure certificate presented for renewal process is not revoked
-		if (await isRevoked(serial)) {
-			l.error("attempt to renew using revoked certificate")
-			throw new ForbiddenException("current certificate is revoked")
-		}
 
 		// use smaller of the current certificate lifetime and the requested lifetime
 		const originalLifetime = (data.body.certificate.validUntil.getTime() - data.body.certificate.validFrom.getTime()) / 1000

--- a/src/api/v3/index.ts
+++ b/src/api/v3/index.ts
@@ -74,7 +74,7 @@ class CaPublicKeyEndpoint extends OpenAPIRoute {
 				default:
 					// otherwise throw as InternalServerErrorException
 					l.error("unhandled error", "error", err)
-					throw new InternalServerErrorException(`${err}`)
+					throw new InternalServerErrorException("internal server error")
 			}
 		}
 	}
@@ -140,7 +140,7 @@ class UserCertificateRequestEndpoint extends OpenAPIRoute {
 				default:
 					// otherwise throw as InternalServerErrorException
 					l.error("unhandled error", "error", err)
-					throw new InternalServerErrorException(`${err}`)
+					throw new InternalServerErrorException("internal server error")
 			}
 		}
 	}
@@ -203,7 +203,7 @@ class RevocationListEndpoint extends OpenAPIRoute {
 				default:
 					// otherwise throw as InternalServerErrorException
 					l.error("unhandled error", "error", err)
-					throw new InternalServerErrorException(`${err}`)
+					throw new InternalServerErrorException("internal server error")
 			}
 		}
 	}
@@ -275,7 +275,7 @@ class HostCertificateRequestEndpoint extends OpenAPIRoute {
 				default:
 					// otherwise throw as InternalServerErrorException
 					l.error("unhandled error", "error", err)
-					throw new InternalServerErrorException(`${err}`)
+					throw new InternalServerErrorException("internal server error")
 			}
 		}
 	}
@@ -338,7 +338,7 @@ class HostCertificateRenewEndpoint extends OpenAPIRoute {
 				default:
 					// otherwise throw as InternalServerErrorException
 					l.error("unhandled error", "error", err)
-					throw new InternalServerErrorException(`${err}`)
+					throw new InternalServerErrorException("internal server error")
 			}
 		}
 	}
@@ -394,7 +394,7 @@ class RevokeCertificateEndpoint extends OpenAPIRoute {
 				default:
 					// otherwise throw as InternalServerErrorException
 					l.error("unhandled error", "error", err)
-					throw new InternalServerErrorException(`${err}`)
+					throw new InternalServerErrorException("internal server error")
 			}
 		}
 	}

--- a/src/api/v3/index.ts
+++ b/src/api/v3/index.ts
@@ -88,23 +88,27 @@ class UserCertificateRequestEndpoint extends OpenAPIRoute {
 		const data = await this.getValidatedData<typeof this.schema>()
 
 		const l = logger.with(
-			...group("request", "type", "user", "action", "request"),
-			...group("auth_token", "email", data.headers.Authorization.email, "sub", data.headers.Authorization.sub),
+			...group("request",
+				"type", "user",
+				"action", "request",
+			),
+			...group("auth_token",
+				"email", data.headers.Authorization.email,
+				"sub", data.headers.Authorization.sub,
+			),
+			...group("id_token",
+				"sub", data.body.identity.sub,
+			),
 		)
 
-		const identity = await parseIdentity(data.body.identity, c.env.JWT_SSH_CERTIFICATE_PRINCIPALS_CLAIM)
-		if (identity.sub !== data.headers["Authorization"].sub) {
-			l.error("token subjects did not match",
-				...group("id_token",
-					"sub", identity.sub,
-				),
-			)
+		if (data.body.identity.sub !== data.headers["Authorization"].sub) {
+			l.error("token subjects did not match")
 			throw new ForbiddenException("Possible token substitution as subjects for authentication and identity tokens did not match")
 		}
 
 		const opts: CreateCertificateOptions = {
 			lifetime: data.body.lifetime,
-			principals: identity.principals,
+			principals: data.body.identity.principals,
 			extensions: data.body.extensions,
 		}
 
@@ -221,20 +225,19 @@ class HostCertificateRequestEndpoint extends OpenAPIRoute {
 				"email", data.headers.Authorization.email,
 				"sub", data.headers.Authorization.sub,
 			),
+			...group("id_token",
+				"sub", data.body.identity.sub,
+			),
 		)
 
-		const identity = await parseIdentity(data.body.identity, c.env.SSH_HOST_CERTIFICATE_ALLOWED_ROLES_CLAIM)
-		if (identity.sub !== data.headers.Authorization.sub) {
-			l.error("token subjects did not match",
-				...group("id_token",
-					"sub", identity.sub,
-				),
-			)
-			throw new ForbiddenException("Possible token substitution as subjects for authentication and identity tokens did not match")
+		// check id and access token are for the same user
+		if (data.body.identity.sub !== data.headers.Authorization.sub) {
+			l.error("token subjects did not match")
+			throw new ForbiddenException("possible token substitution as subjects for authentication and identity tokens did not match")
 		}
 
 		// check user can issue host certificates
-		if (!split(c.env.SSH_HOST_CERTIFICATE_ALLOWED_EMAILS).includes(data.headers.Authorization.email) && !identity.principals.some((p: string) => split(env.SSH_HOST_CERTIFICATE_ALLOWED_ROLES).includes(p))) {
+		if (!split(c.env.SSH_HOST_CERTIFICATE_ALLOWED_EMAILS).includes(data.headers.Authorization.email) && !data.body.identity.principals.some((p: string) => split(env.SSH_HOST_CERTIFICATE_ALLOWED_ROLES).includes(p))) {
 			l.error("unauthorized host certificate request")
 			throw new UnauthorizedException("User not allowed to issue host certificates")
 		}

--- a/src/api/v3/schema.ts
+++ b/src/api/v3/schema.ts
@@ -10,6 +10,7 @@ import {
 	transformCertificate,
 	refineHostCertificateRenewal,
 	refineRevokeCertificate,
+	transformIdentityToken,
 } from "../../utils"
 import {
 	ConflictException,
@@ -52,6 +53,7 @@ const identityToken = z.string()
 		description: "Identity Token JWT from OIDC IdP",
 		example: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZW1haWwiOiJ1c2VyQGV4YW1wbGUuY29tIiwiaWF0IjoxNzc1NzAzMDk1fQ.ri_neAWnhMNK3LzlsrBcQYymSM4yRjmNSZZSeZiXhrEqtEz6c3cXk0Esq765umGjpUsWcosL-OFrDJlyAjTDnhrd9oV08uc_CW0rQRsJIGEuRo3ryxkLdVu9mGoZWEUb9KwjGJrwxvr-0cPWx5jaDyKwJcqMvtV_bEITUD51sDB1Vm89QfYRO_pGJo2vrRzSvMjpUenRpwPay4lYIBxl41_4YpR9Rc6VrIZuYsjV2iqEZ4eBrygMA7zPR_hN7l7s95FddLOzj5NsK57VT4uLHwYohx2oqMzw3M-B9HsZIQin_9q61pZFQXepzJth0woXiZheU27llnfHX967PhNQyg"
 	})
+	.transform(transformIdentityToken)
 
 const accessToken = z.string()
 	.meta({

--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -61,9 +61,7 @@ export const generateCertificate = (email: string, key: PrivateKey, public_key: 
 		: seconds(env.SSH_CERTIFICATE_LIFETIME)
 
 	// generate value for serial of certificate
-	const now = options?.now ?? Date.now()
-	const serial = Buffer.alloc(8)
-	serial.writeBigUInt64BE(BigInt(now))
+	const serial = generateSerial()
 
 	// set issuer of certificate based on ISSUER_DN
 	const issuer = identityFromDN(env.ISSUER_DN)
@@ -176,9 +174,7 @@ export async function createSignedHostCertificate(public_key: Key, options: Crea
 		: seconds(env.SSH_HOST_CERTIFICATE_LIFETIME)
 
 	// generate value for serial of certificate
-	const unixTimestamp = Date.now()
-	const serial = Buffer.alloc(8)
-	serial.writeBigUInt64BE(BigInt(unixTimestamp))
+	const serial = generateSerial()
 
 	// set issuer of certificate based on ISSUER_DN
 	const issuer = identityFromDN(env.ISSUER_DN)
@@ -187,4 +183,9 @@ export async function createSignedHostCertificate(public_key: Key, options: Crea
 	const certificate = createCertificate(identity, public_key, issuer, key, { lifetime: lifetime, serial: serial })
 
 	return certificate
+}
+
+const generateSerial = (): Buffer<ArrayBuffer> => {
+	const randomBytes = crypto.getRandomValues(new Uint8Array(8))
+	return Buffer.from(randomBytes)
 }

--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -7,193 +7,184 @@ import { split } from "./utils"
 const sshCertificateExtensions = split(env.SSH_CERTIFICATE_EXTENSIONS)
 
 export type CreateCertificateOptions = {
-    lifetime?: number
-    principals?: string[]
-    extensions?: string[]
+	lifetime?: number
+	principals?: string[]
+	extensions?: string[]
 }
 
 const DefaultCreateCertificateOptions: CreateCertificateOptions = {
-    lifetime: seconds(env.SSH_CERTIFICATE_LIFETIME),
-    principals: [],
-    extensions: sshCertificateExtensions
+	lifetime: seconds(env.SSH_CERTIFICATE_LIFETIME),
+	principals: [],
+	extensions: sshCertificateExtensions
 }
 
 export class CertificateError extends Error {
-    constructor(message: string) {
-    super(message)
-    this.name = "CertificateError"
+	constructor(message: string) {
+		super(message)
+		this.name = "CertificateError"
 
-    // This is necessary for proper stack trace in TypeScript
-    Object.setPrototypeOf(this, CertificateError.prototype)
-  }
+		// This is necessary for proper stack trace in TypeScript
+		Object.setPrototypeOf(this, CertificateError.prototype)
+	}
 }
 
 export type GenerateCertificateOptions = {
-    /**
-     * @internal
-     * Override the current timestamp used for the certificate serial number.
-     * Should only be set in tests.
-     */
-    now?: number
+	/**
+	 * @internal
+	 * Override the current timestamp used for the certificate serial number.
+	 * Should only be set in tests.
+	 */
+	now?: number
 } & CreateCertificateOptions
 
 export const generateCertificate = (email: string, key: PrivateKey, public_key: Key, options?: GenerateCertificateOptions): Certificate => {
-    let { lifetime, principals, extensions } = options ?? {}
+	let { lifetime, principals, extensions } = options ?? {}
 
-    // add identities
-    const identity = env.SSH_CERTIFICATE_INCLUDE_SELF as string === "true"
-        ? [identityForUser(email.split("@")[0])]
-        : []
-    if (principals !== undefined) {
-        for (const p of principals) {
-            identity.push(identityForUser(p))
-        }
-    }
-    if (env.SSH_CERTIFICATE_PRINCIPALS as string !== "") {
-        for (const p of split(env.SSH_CERTIFICATE_PRINCIPALS)) {
-            identity.push(identityForUser(p))
-        }
-    }
+	// add identities
+	const identity = env.SSH_CERTIFICATE_INCLUDE_SELF as string === "true"
+		? [identityForUser(email.split("@")[0])]
+		: []
+	if (principals !== undefined) {
+		for (const p of principals) {
+			identity.push(identityForUser(p))
+		}
+	}
+	if (env.SSH_CERTIFICATE_PRINCIPALS as string !== "") {
+		for (const p of split(env.SSH_CERTIFICATE_PRINCIPALS)) {
+			identity.push(identityForUser(p))
+		}
+	}
 
-    // lifetime is the smaller of what was provided in the options or the default
-    lifetime = lifetime !== undefined
-        ? Math.min(lifetime, seconds(env.SSH_CERTIFICATE_LIFETIME))
-        : seconds(env.SSH_CERTIFICATE_LIFETIME)
+	// lifetime is the smaller of what was provided in the options or the default
+	lifetime = lifetime !== undefined
+		? Math.min(lifetime, seconds(env.SSH_CERTIFICATE_LIFETIME))
+		: seconds(env.SSH_CERTIFICATE_LIFETIME)
 
-    // generate value for serial of certificate
-    const now = options?.now ?? Date.now()
-    const serial = Buffer.alloc(8)
-    serial.writeBigUInt64BE(BigInt(now))
+	// generate value for serial of certificate
+	const now = options?.now ?? Date.now()
+	const serial = Buffer.alloc(8)
+	serial.writeBigUInt64BE(BigInt(now))
 
-    // set issuer of certificate based on ISSUER_DN
-    const issuer = identityFromDN(env.ISSUER_DN)
+	// set issuer of certificate based on ISSUER_DN
+	const issuer = identityFromDN(env.ISSUER_DN)
 
-    // create certificate
-    const certificate = createCertificate(identity, public_key, issuer, key, { lifetime: lifetime, serial: serial })
+	// create certificate
+	const certificate = createCertificate(identity, public_key, issuer, key, { lifetime: lifetime, serial: serial })
 
 	// ensure openssh info is included in certificate (should not occur)
 	if (certificate.signatures.openssh === undefined) {
 		throw new CertificateError("missing openssh information in certificate")
 	}
 
-    // add usage extensions
-    const sshextensions: SSHExtension[] = []
-    if (extensions !== undefined) {
-        // if extensions are provided in request, ensure they do not include extra extensions beyond the defaults
-        for (const ext of extensions) {
-            if (!sshCertificateExtensions.includes(ext)) {
-                throw new CertificateError(`${ext} is not allowed`)
-            }
+	// add usage extensions
+	const sshextensions: SSHExtension[] = []
+	if (extensions !== undefined) {
+		// if extensions are provided in request, ensure they do not include extra extensions beyond the defaults
+		for (const ext of extensions) {
+			if (!sshCertificateExtensions.includes(ext)) {
+				throw new CertificateError(`${ext} is not allowed`)
+			}
 
-            // add to list of allowed extensions
-            sshextensions.push({
-                critical: false,
-                name: ext,
-                data: Buffer.alloc(0)
-            })
-        }
-    } else {
-        // use defaults if not provided
-        sshCertificateExtensions.forEach((ext: string) => {
-            sshextensions.push({
-                critical: false,
-                name: ext,
-                data: Buffer.alloc(0)
-            })
-        })
+			// add to list of allowed extensions
+			sshextensions.push({
+				critical: false,
+				name: ext,
+				data: Buffer.alloc(0)
+			})
+		}
+	} else {
+		// use defaults if not provided
+		sshCertificateExtensions.forEach((ext: string) => {
+			sshextensions.push({
+				critical: false,
+				name: ext,
+				data: Buffer.alloc(0)
+			})
+		})
 
-    }
+	}
 
-    // add info to certificate
-    certificate.signatures = {
-        openssh: {
-            nonce: certificate.signatures.openssh.nonce,
-            keyId: email,
-            signature: certificate.signatures.openssh.signature,
-            exts: sshextensions
-        }
-    }
+	// add info to certificate
+	certificate.signatures = {
+		openssh: {
+			nonce: certificate.signatures.openssh.nonce,
+			keyId: email,
+			signature: certificate.signatures.openssh.signature,
+			exts: sshextensions
+		}
+	}
 
-    // re-sign after changes
-    certificate.signWith(key)
+	// re-sign after changes
+	certificate.signWith(key)
 
-    return certificate
+	return certificate
 }
 
 export async function createSignedCertificate(email: string, public_key: Key, options: CreateCertificateOptions = DefaultCreateCertificateOptions): Promise<Certificate> {
-    // grab private key from secret store
+	// grab private key from secret store
 	const secret = await env.PRIVATE_KEY.get()
 
 	// parse key
-    const key = parsePrivateKey(secret)
+	const key = parsePrivateKey(secret)
 
-    return generateCertificate(email, key, public_key, options)
+	return generateCertificate(email, key, public_key, options)
 }
 
 export type CreateHostCertificateOptions = {
-    lifetime?: number
-    principals?: string[]
-    subjects?: Identity[]
-    certificate?: Certificate
+	lifetime?: number
+	principals?: string[]
+	subjects?: Identity[]
 }
 
 const DefaultCreateHostertificateOptions: CreateHostCertificateOptions = {
-    lifetime: seconds(env.SSH_HOST_CERTIFICATE_LIFETIME),
-    principals: [],
+	lifetime: seconds(env.SSH_HOST_CERTIFICATE_LIFETIME),
+	principals: [],
 }
 
 export class BadIssuerError extends Error {
-    constructor(message: string) {
-    super(message)
-    this.name = "BadIssuerError"
+	constructor(message: string) {
+		super(message)
+		this.name = "BadIssuerError"
 
-    Object.setPrototypeOf(this, BadIssuerError.prototype)
-  }
+		Object.setPrototypeOf(this, BadIssuerError.prototype)
+	}
 }
 
 export async function createSignedHostCertificate(public_key: Key, options: CreateHostCertificateOptions = DefaultCreateHostertificateOptions): Promise<Certificate> {
-    // generate list of identities for host key
-    const identity: Identity[] = []
-    if (options.principals !== undefined) {
-        for (const p of options.principals) {
-            identity.push(identityForHost(p))
-        }
-    }
+	// generate list of identities for host key
+	const identity: Identity[] = []
+	if (options.principals !== undefined) {
+		for (const p of options.principals) {
+			identity.push(identityForHost(p))
+		}
+	}
 
-    // add any already provided subjects (for renewals only)
-    if (options.subjects !== undefined) {
-        identity.push(...options.subjects)
-    }
+	// add any already provided subjects (for renewals only)
+	if (options.subjects !== undefined) {
+		identity.push(...options.subjects)
+	}
 
-    // grab private key from secret store
+	// grab private key from secret store
 	const secret = await env.PRIVATE_KEY.get()
 
 	// parse private key
-    const key = parsePrivateKey(secret)
+	const key = parsePrivateKey(secret)
 
-    // check certificate was issued by us if provided (for renewals)
-    if (options.certificate !== undefined) {
-        const issuer = key.toPublic()
-        if (!options.certificate.isSignedByKey(issuer)) {
-            throw new BadIssuerError("the provided certificate was not signed by this CA")
-        }
-    }
+	// lifetime is the smaller of what was provided in the options or the default
+	const lifetime = options.lifetime !== undefined
+		? Math.min(options.lifetime, seconds(env.SSH_HOST_CERTIFICATE_LIFETIME))
+		: seconds(env.SSH_HOST_CERTIFICATE_LIFETIME)
 
-    // lifetime is the smaller of what was provided in the options or the default
-    const lifetime = options.lifetime !== undefined
-        ? Math.min(options.lifetime, seconds(env.SSH_HOST_CERTIFICATE_LIFETIME))
-        : seconds(env.SSH_HOST_CERTIFICATE_LIFETIME)
+	// generate value for serial of certificate
+	const unixTimestamp = Date.now()
+	const serial = Buffer.alloc(8)
+	serial.writeBigUInt64BE(BigInt(unixTimestamp))
 
-    // generate value for serial of certificate
-    const unixTimestamp = Date.now()
-    const serial = Buffer.alloc(8)
-    serial.writeBigUInt64BE(BigInt(unixTimestamp))
+	// set issuer of certificate based on ISSUER_DN
+	const issuer = identityFromDN(env.ISSUER_DN)
 
-    // set issuer of certificate based on ISSUER_DN
-    const issuer = identityFromDN(env.ISSUER_DN)
+	// create certificate
+	const certificate = createCertificate(identity, public_key, issuer, key, { lifetime: lifetime, serial: serial })
 
-    // create certificate
-    const certificate = createCertificate(identity, public_key, issuer, key, { lifetime: lifetime, serial: serial })
-
-    return certificate
+	return certificate
 }

--- a/src/certificate.ts
+++ b/src/certificate.ts
@@ -31,14 +31,14 @@ export class CertificateError extends Error {
 export type GenerateCertificateOptions = {
 	/**
 	 * @internal
-	 * Override the current timestamp used for the certificate serial number.
+	 * Override the certificate serial number.
 	 * Should only be set in tests.
 	 */
-	now?: number
+	serial?: bigint
 } & CreateCertificateOptions
 
 export const generateCertificate = (email: string, key: PrivateKey, public_key: Key, options?: GenerateCertificateOptions): Certificate => {
-	let { lifetime, principals, extensions } = options ?? {}
+	let { lifetime, principals, extensions, serial } = options ?? {}
 
 	// add identities
 	const identity = env.SSH_CERTIFICATE_INCLUDE_SELF as string === "true"
@@ -61,13 +61,13 @@ export const generateCertificate = (email: string, key: PrivateKey, public_key: 
 		: seconds(env.SSH_CERTIFICATE_LIFETIME)
 
 	// generate value for serial of certificate
-	const serial = generateSerial()
+	const s = generateSerial(serial)
 
 	// set issuer of certificate based on ISSUER_DN
 	const issuer = identityFromDN(env.ISSUER_DN)
 
 	// create certificate
-	const certificate = createCertificate(identity, public_key, issuer, key, { lifetime: lifetime, serial: serial })
+	const certificate = createCertificate(identity, public_key, issuer, key, { lifetime: lifetime, serial: s })
 
 	// ensure openssh info is included in certificate (should not occur)
 	if (certificate.signatures.openssh === undefined) {
@@ -185,7 +185,14 @@ export async function createSignedHostCertificate(public_key: Key, options: Crea
 	return certificate
 }
 
-const generateSerial = (): Buffer<ArrayBuffer> => {
+export const generateSerial = (serial?: bigint): Buffer<ArrayBuffer> => {
+	if (serial !== undefined) {
+		const s = Buffer.alloc(8)
+		s.writeBigUInt64BE(serial)
+
+		return s
+	}
+
 	const randomBytes = crypto.getRandomValues(new Uint8Array(8))
 	return Buffer.from(randomBytes)
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -15,13 +15,6 @@ export const app = new Hono()
 // add error handling
 app.onError((err, c) => {
     if (err instanceof HTTPException) {
-        const message = err.message === "" ? "got HTTPException from router" : err.message
-        if (err.cause !== undefined) {
-            logger.error(message, "status", err.status, "cause", err.cause)
-        } else {
-            logger.error(message, "status", err.status)
-        }
-
         return err.getResponse()
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,12 +47,12 @@ export const transformProofOfPossession = (val: string, ctx: z.core.$RefinementC
 	}
 }
 
-type ParsedAuthorizationHeader = {
+type AccessToken = {
 	email: string
 	sub: string
 }
 
-export const transformAuthorizationHeader = async (val: string, ctx: z.RefinementCtx): Promise<ParsedAuthorizationHeader | never> => {
+export const transformAuthorizationHeader = async (val: string, ctx: z.RefinementCtx): Promise<AccessToken | never> => {
 	// skip this when running locally
 	if (env.IS_PRODUCTION as string === "false") {
 		return {
@@ -160,17 +160,14 @@ export const identityPrincipals = (payload: CertificateRequestJWTPayload, claim?
 	return principals
 }
 
-type ParsedIdentity = {
+type IdentityToken = {
 	sub: string
 	principals: string[]
 }
 
-export const parseIdentity = async (jwt: string | undefined, claim?: string): Promise<ParsedIdentity> => {
+export const parseIdentity = async (jwt: string | undefined, claim?: string): Promise<IdentityToken> => {
 	if (jwt === undefined) {
-		return {
-			sub: "",
-			principals: []
-		}
+		throw new Error("missing identity token")
 	}
 
 	const aud = env.JWT_AUD === undefined || env.JWT_AUD as string === "" ? undefined : split(env.JWT_AUD as string)
@@ -181,6 +178,21 @@ export const parseIdentity = async (jwt: string | undefined, claim?: string): Pr
 	return {
 		sub: payload.sub,
 		principals: principals,
+	}
+}
+
+export const transformIdentityToken = async (val: string, ctx: z.RefinementCtx): Promise<IdentityToken | never> => {
+	try {
+		const identity = await parseIdentity(val, env.JWT_SSH_CERTIFICATE_PRINCIPALS_CLAIM)
+
+		return identity
+	} catch (err) {
+		ctx.issues.push({
+			code: "custom",
+			message: "problem parsing identity token",
+			input: val
+		})
+		return z.NEVER
 	}
 }
 
@@ -227,7 +239,7 @@ type ParsedCertificateRequest = {
 	proof: ProofOfPossession
 	public_key: Key
 	lifetime: number
-	identity: string
+	identity: IdentityToken
 	extensions: string[]
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,181 +6,182 @@ import { verifyJWT } from "./verify"
 import { CertificateRequestJWTPayload } from "./types"
 import { Logger } from "@andrewheberle/ts-slog"
 import { HostProofOfPossession, ProofOfPossession, PossessionParseError } from "./proof"
+import { isRevoked } from "./db"
 
 const logger = new Logger()
 
 export const fatalIssue = (ctx: z.RefinementCtx, message: string, val: unknown) => {
-    ctx.issues.push({
-        code: "custom",
-        message: message,
-        input: val
-    })
+	ctx.issues.push({
+		code: "custom",
+		message: message,
+		input: val
+	})
 
-    return z.NEVER
+	return z.NEVER
 }
 
 export const transformProofOfPossession = (val: string, ctx: z.core.$RefinementCtx<string>): ProofOfPossession | never => {
-    try {
-        const proof = new ProofOfPossession(val)
+	try {
+		const proof = new ProofOfPossession(val)
 
-        return proof
-    } catch (err) {
-        logger.error("proof of possession parsing error", "error", err)
-        switch (true) {
-            case (err instanceof PossessionParseError):
-                ctx.issues.push({
-                    code: "custom",
-                    message: err.message,
-                    input: val
-                })
-                break
-            default:
-                ctx.issues.push({
-                    code: "custom",
-                    message: "proof of possession transform unhandled error",
-                    input: val
-                })
-        }
+		return proof
+	} catch (err) {
+		logger.error("proof of possession parsing error", "error", err)
+		switch (true) {
+			case (err instanceof PossessionParseError):
+				ctx.issues.push({
+					code: "custom",
+					message: err.message,
+					input: val
+				})
+				break
+			default:
+				ctx.issues.push({
+					code: "custom",
+					message: "proof of possession transform unhandled error",
+					input: val
+				})
+		}
 
-        return z.NEVER
-    }
+		return z.NEVER
+	}
 }
 
 type ParsedAuthorizationHeader = {
-    email: string
-    sub: string
+	email: string
+	sub: string
 }
 
 export const transformAuthorizationHeader = async (val: string, ctx: z.RefinementCtx): Promise<ParsedAuthorizationHeader | never> => {
-    // skip this when running locally
-    if (env.IS_PRODUCTION as string === "false") {
-        return {
-            email: "text@example.com",
-            sub: "test",
-        }
-    }
+	// skip this when running locally
+	if (env.IS_PRODUCTION as string === "false") {
+		return {
+			email: "text@example.com",
+			sub: "test",
+		}
+	}
 
-    const jwt = val.replace("Bearer ", "")
+	const jwt = val.replace("Bearer ", "")
 
-    if (jwt === "") {
-        return fatalIssue(ctx, "request did not contain a JWT", val)
-    }
+	if (jwt === "") {
+		return fatalIssue(ctx, "request did not contain a JWT", val)
+	}
 
-    try {
-        // verify jwt
-        const { payload } = await verifyJWT(jwt)
+	try {
+		// verify jwt
+		const { payload } = await verifyJWT(jwt)
 
-        if (payload.email === undefined) {
-            return fatalIssue(ctx, "JWT was verified but was missing required email claim", val)
-        }
+		if (payload.email === undefined) {
+			return fatalIssue(ctx, "JWT was verified but was missing required email claim", val)
+		}
 
-        return {
-            email: payload.email,
-            sub: payload.sub,
-        }
-    } catch (err) {
-        switch (true) {
-            case (err instanceof JWSInvalid):
-                return fatalIssue(ctx, "the access token was invalid", val)
-            case (err instanceof JWTInvalid):
-                return fatalIssue(ctx, "the access token failed verification", val)
-            case (err instanceof JWKInvalid):
-                return fatalIssue(ctx, "the access token JWK was invalid", val)
-            case (err instanceof JWKSInvalid):
-                return fatalIssue(ctx, "the access token JWKS was invalid", val)
+		return {
+			email: payload.email,
+			sub: payload.sub,
+		}
+	} catch (err) {
+		switch (true) {
+			case (err instanceof JWSInvalid):
+				return fatalIssue(ctx, "the access token was invalid", val)
+			case (err instanceof JWTInvalid):
+				return fatalIssue(ctx, "the access token failed verification", val)
+			case (err instanceof JWKInvalid):
+				return fatalIssue(ctx, "the access token JWK was invalid", val)
+			case (err instanceof JWKSInvalid):
+				return fatalIssue(ctx, "the access token JWKS was invalid", val)
 			case (err instanceof JWTClaimValidationFailed):
 				return fatalIssue(ctx, "claim validtion of the JWT failed", val)
-            default:
+			default:
 				logger.error("unhandled access token validation error", "in", "transformAuthorizationHeader", "error", err)
-                return fatalIssue(ctx, "unhandled access token validation error", val)
-        }
-    }
+				return fatalIssue(ctx, "unhandled access token validation error", val)
+		}
+	}
 }
 
 export const transformPublicKey = (val: string | Buffer<ArrayBufferLike>, ctx: z.RefinementCtx): Key | never => {
-    try {
-        const key = typeof val === "string" ? parseKey(Buffer.from(val, "base64")) : parseKey(val)
+	try {
+		const key = typeof val === "string" ? parseKey(Buffer.from(val, "base64")) : parseKey(val)
 
-        return key
-    } catch (err) {
-        switch (true) {
-            case (err instanceof TypeError):
-                ctx.issues.push({
-                    code: "custom",
-                    message: err.message,
-                    input: val
-                })
-                break
-            case (err instanceof KeyParseError):
-                ctx.issues.push({
-                    code: "custom",
-                    message: err.message,
-                    input: val
-                })
-                break
-            default:
-                ctx.issues.push({
-                    code: "custom",
-                    message: "unhandled error parsing public_key",
-                    input: val
-                })
-        }
+		return key
+	} catch (err) {
+		switch (true) {
+			case (err instanceof TypeError):
+				ctx.issues.push({
+					code: "custom",
+					message: err.message,
+					input: val
+				})
+				break
+			case (err instanceof KeyParseError):
+				ctx.issues.push({
+					code: "custom",
+					message: err.message,
+					input: val
+				})
+				break
+			default:
+				ctx.issues.push({
+					code: "custom",
+					message: "unhandled error parsing public_key",
+					input: val
+				})
+		}
 
-        return z.NEVER
-    }
+		return z.NEVER
+	}
 }
 
 export const identityPrincipals = (payload: CertificateRequestJWTPayload, claim?: string): string[] => {
-    if (claim === undefined) {
-        claim = env.JWT_SSH_CERTIFICATE_PRINCIPALS_CLAIM
-    }
+	if (claim === undefined) {
+		claim = env.JWT_SSH_CERTIFICATE_PRINCIPALS_CLAIM
+	}
 
-    const p = payload[claim]
-    if (p === undefined) {
-        logger.warn("claim was missing despite being set in CA config", "claim", claim)
-        return []
-    }
+	const p = payload[claim]
+	if (p === undefined) {
+		logger.warn("claim was missing despite being set in CA config", "claim", claim)
+		return []
+	}
 
-    if (p === "") {
-        logger.warn("claim was present but was an empty string", "claim", claim)
-        return []
-    }
+	if (p === "") {
+		logger.warn("claim was present but was an empty string", "claim", claim)
+		return []
+	}
 
-    // make sure its always a string[]
-    const principals = typeof p === "string" ? [p] : p
+	// make sure its always a string[]
+	const principals = typeof p === "string" ? [p] : p
 
-    // replace any spaces with underscores
-    principals.forEach((value, index, array) => {
-        array[index] = value.replaceAll(" ", "_")
-    })
+	// replace any spaces with underscores
+	principals.forEach((value, index, array) => {
+		array[index] = value.replaceAll(" ", "_")
+	})
 
-    logger.info("identity token included principals", "principals", principals)
+	logger.info("identity token included principals", "principals", principals)
 
-    return principals
+	return principals
 }
 
 type ParsedIdentity = {
-    sub: string
-    principals: string[]
+	sub: string
+	principals: string[]
 }
 
 export const parseIdentity = async (jwt: string | undefined, claim?: string): Promise<ParsedIdentity> => {
-    if (jwt === undefined) {
-        return {
-            sub: "",
-            principals: []
-        }
-    }
+	if (jwt === undefined) {
+		return {
+			sub: "",
+			principals: []
+		}
+	}
 
 	const aud = env.JWT_AUD === undefined || env.JWT_AUD as string === "" ? undefined : split(env.JWT_AUD as string)
-    const { payload } = await verifyJWT(jwt, { aud: aud })
+	const { payload } = await verifyJWT(jwt, { aud: aud })
 
-    const principals = identityPrincipals(payload, claim)
+	const principals = identityPrincipals(payload, claim)
 
-    return {
-        sub: payload.sub,
-        principals: principals,
-    }
+	return {
+		sub: payload.sub,
+		principals: principals,
+	}
 }
 
 /**
@@ -190,188 +191,200 @@ export const parseIdentity = async (jwt: string | undefined, claim?: string): Pr
  * @returns
  */
 export const transformCertificate = (val: string | Buffer<ArrayBufferLike>, ctx: z.RefinementCtx): Certificate | never => {
-    try {
-        const cert = typeof val === "string" ? parseCertificate(Buffer.from(val, "base64"), "openssh") : parseCertificate(val, "openssh")
+	try {
+		const cert = typeof val === "string" ? parseCertificate(Buffer.from(val, "base64"), "openssh") : parseCertificate(val, "openssh")
 
-        return cert
-    } catch (err) {
-        switch (true) {
-            case (err instanceof TypeError):
-                ctx.issues.push({
-                    code: "custom",
-                    message: err.message,
-                    input: val
-                })
-                break
-            case (err instanceof CertificateParseError):
-                ctx.issues.push({
-                    code: "custom",
-                    message: err.message,
-                    input: val
-                })
-                break
-            default:
-                ctx.issues.push({
-                    code: "custom",
-                    message: "unhandled error parsing certificate",
-                    input: val
-                })
-        }
+		return cert
+	} catch (err) {
+		switch (true) {
+			case (err instanceof TypeError):
+				ctx.issues.push({
+					code: "custom",
+					message: err.message,
+					input: val
+				})
+				break
+			case (err instanceof CertificateParseError):
+				ctx.issues.push({
+					code: "custom",
+					message: err.message,
+					input: val
+				})
+				break
+			default:
+				ctx.issues.push({
+					code: "custom",
+					message: "unhandled error parsing certificate",
+					input: val
+				})
+		}
 
-        return z.NEVER
-    }
+		return z.NEVER
+	}
 }
 
 type ParsedCertificateRequest = {
-    proof: ProofOfPossession
-    public_key: Key
-    lifetime: number
-    identity: string
-    extensions: string[]
+	proof: ProofOfPossession
+	public_key: Key
+	lifetime: number
+	identity: string
+	extensions: string[]
 }
 
 export const refineCertificateRequest = async (val: ParsedCertificateRequest, ctx: z.RefinementCtx): Promise<never> => {
-    try {
-        // check proof of possession fingerprint matches public key
-        if (!val.proof.matches(val.public_key)) {
-            return fatalIssue(ctx, "proof of possession fingerprint did not match public_key", val)
-        }
+	try {
+		// check proof of possession fingerprint matches public key
+		if (!val.proof.matches(val.public_key)) {
+			return fatalIssue(ctx, "proof of possession fingerprint did not match public_key", val)
+		}
 
-        // verify proof of possession signature
-        const verified = await val.proof.verify()
-        if (!verified) {
-            return fatalIssue(ctx, "proof of possession signature validation failed", val)
-        }
+		// verify proof of possession signature
+		const verified = await val.proof.verify()
+		if (!verified) {
+			return fatalIssue(ctx, "proof of possession signature validation failed", val)
+		}
 
-        return z.NEVER
-    } catch (err) {
+		return z.NEVER
+	} catch (err) {
 		logger.error("proof of possession verification unhandled error", "in", "refineCertificateRequest", "error", err)
-        return fatalIssue(ctx, "proof of possession verification unhandled error", val)
-    }
+		return fatalIssue(ctx, "proof of possession verification unhandled error", val)
+	}
 }
 
 type LegacyParsedCertificateRequest = {
-    nonce: ProofOfPossession
-    public_key: Key
-    lifetime: number
-    identity: string
-    extensions: string[]
+	nonce: ProofOfPossession
+	public_key: Key
+	lifetime: number
+	identity: string
+	extensions: string[]
 }
 
 export const refineLegacyCertificateRequest = async (val: LegacyParsedCertificateRequest, ctx: z.RefinementCtx): Promise<never> => {
-    try {
-        // check proof of possession fingerprint matches public key
-        if (!val.nonce.matches(val.public_key)) {
-            return fatalIssue(ctx, "proof of possession fingerprint did not match public_key", val)
-        }
+	try {
+		// check proof of possession fingerprint matches public key
+		if (!val.nonce.matches(val.public_key)) {
+			return fatalIssue(ctx, "proof of possession fingerprint did not match public_key", val)
+		}
 
-        // verify proof of possession signature
-        const verified = await val.nonce.verify("file")
-        if (!verified) {
-            return fatalIssue(ctx, "proof of possession signature validation failed", val)
-        }
+		// verify proof of possession signature
+		const verified = await val.nonce.verify("file")
+		if (!verified) {
+			return fatalIssue(ctx, "proof of possession signature validation failed", val)
+		}
 
-        return z.NEVER
-    } catch (err) {
-        return fatalIssue(ctx, "proof of possession verification unhandled error", val)
-    }
+		return z.NEVER
+	} catch (err) {
+		return fatalIssue(ctx, "proof of possession verification unhandled error", val)
+	}
 }
 
 export const transformHostProofOfPossession = (val: string, ctx: z.RefinementCtx): HostProofOfPossession | never => {
-    try {
-        return new HostProofOfPossession(val)
-    } catch (err) {
-        if (err instanceof PossessionParseError) {
-            return fatalIssue(ctx, err.message, val)
-        }
+	try {
+		return new HostProofOfPossession(val)
+	} catch (err) {
+		if (err instanceof PossessionParseError) {
+			return fatalIssue(ctx, err.message, val)
+		}
 
 		logger.error("proof of possession verification unhandled error", "in", "transformHostProofOfPossession", "error", err)
-        return fatalIssue(ctx, "proof of possession transform unhandled error", val)
-    }
+		return fatalIssue(ctx, "proof of possession transform unhandled error", val)
+	}
 }
 
 type HostCertificateRequest = {
-    public_key: Key
-    lifetime: number
+	public_key: Key
+	lifetime: number
 }
 
 type ParsedHostCertificateRequest = {
-    principals: string[]
-    proof: ProofOfPossession
+	principals: string[]
+	proof: ProofOfPossession
 } & HostCertificateRequest
 
 export const refineHostCertificateRequest = async (val: ParsedHostCertificateRequest, ctx: z.RefinementCtx): Promise<never> => {
-    try {
-        // check proof of possession fingerprint matches public key
-        if (!val.proof.matches(val.public_key)) {
-            return fatalIssue(ctx, "proof of possession fingerprint did not match public_key", val)
-        }
+	try {
+		// check proof of possession fingerprint matches public key
+		if (!val.proof.matches(val.public_key)) {
+			return fatalIssue(ctx, "proof of possession fingerprint did not match public_key", val)
+		}
 
-        // verify proof of possession signature
-        const verified = await val.proof.verify()
-        if (!verified) {
-            return fatalIssue(ctx, "proof of possession signature validation failed", val)
-        }
+		// verify proof of possession signature
+		const verified = await val.proof.verify()
+		if (!verified) {
+			return fatalIssue(ctx, "proof of possession signature validation failed", val)
+		}
 
-        return z.NEVER
-    } catch (err) {
+		return z.NEVER
+	} catch (err) {
 		logger.error("proof of possession verification unhandled error", "in", "refineHostCertificateRequest", "error", err)
-        return fatalIssue(ctx, "proof of possession verification unhandled error", val)
-    }
+		return fatalIssue(ctx, "proof of possession verification unhandled error", val)
+	}
 }
 
 type LegacyParsedHostCertificateRequest = {
-    principals: string[]
-    nonce: ProofOfPossession
+	principals: string[]
+	nonce: ProofOfPossession
 } & HostCertificateRequest
 
 export const refineLegacyHostCertificateRequest = async (val: LegacyParsedHostCertificateRequest, ctx: z.RefinementCtx): Promise<never> => {
-    try {
-        // check proof of possession fingerprint matches public key
-        if (!val.nonce.matches(val.public_key)) {
-            return fatalIssue(ctx, "proof of possession fingerprint did not match public_key", val)
-        }
+	try {
+		// check proof of possession fingerprint matches public key
+		if (!val.nonce.matches(val.public_key)) {
+			return fatalIssue(ctx, "proof of possession fingerprint did not match public_key", val)
+		}
 
-        // verify proof of possession signature
-        const verified = await val.nonce.verify("file")
-        if (!verified) {
-            return fatalIssue(ctx, "proof of possession signature validation failed", val)
-        }
+		// verify proof of possession signature
+		const verified = await val.nonce.verify("file")
+		if (!verified) {
+			return fatalIssue(ctx, "proof of possession signature validation failed", val)
+		}
 
-        return z.NEVER
-    } catch (err) {
-        return fatalIssue(ctx, "proof of possession verification unhandled error", val)
-    }
+		return z.NEVER
+	} catch (err) {
+		return fatalIssue(ctx, "proof of possession verification unhandled error", val)
+	}
 }
 
 type ParsedHostCertificateRenewal = {
-    certificate: Certificate
-    proof: HostProofOfPossession
+	certificate: Certificate
+	proof: HostProofOfPossession
 } & HostCertificateRequest
 
 export const refineHostCertificateRenewal = async (val: ParsedHostCertificateRenewal, ctx: z.RefinementCtx): Promise<never> => {
-    try {
-        // check certificate is not expired
-        if (val.certificate.isExpired()) {
-            return fatalIssue(ctx, "certificate is expired", val)
-        }
+	try {
+		// ensure certificate is signed by CA
+		const issuer = await getPublic()
+		if (!val.certificate.isSignedByKey(issuer)) {
+			return fatalIssue(ctx, "the provided certificate was not signed by this CA", val)
+		}
 
-        // check proof of possession fingerprint matches public key and certificate subject key
-        if (!val.proof.matches(val.public_key, val.certificate.subjectKey)) {
-            return fatalIssue(ctx, "proof of possession fingerprints did not match public_key and/or certificate", val)
-        }
+		// check certificate is not expired
+		if (val.certificate.isExpired()) {
+			return fatalIssue(ctx, "the provided certificate is expired", val)
+		}
 
-        // verify proof of possession signature
-        const verified = await val.proof.verify()
-        if (!verified) {
-            return fatalIssue(ctx, "proof of possession signature validation failed", val)
-        }
+		// ensure certificate presented for renewal is not revoked
+		const serial = val.certificate.serial.readBigUInt64BE(0)
+		if (await isRevoked(serial)) {
+			return fatalIssue(ctx, "the provided certificate is revoked", val)
+		}
 
-        return z.NEVER
-    } catch (err) {
+		// check proof of possession fingerprint matches public key and certificate subject key
+		if (!val.proof.matches(val.public_key, val.certificate.subjectKey)) {
+			return fatalIssue(ctx, "proof of possession fingerprints did not match public_key and/or certificate", val)
+		}
+
+		// verify proof of possession signature
+		const verified = await val.proof.verify()
+		if (!verified) {
+			return fatalIssue(ctx, "proof of possession signature validation failed", val)
+		}
+
+		return z.NEVER
+	} catch (err) {
 		logger.error("proof of possession verification unhandled error", "in", "refineHostCertificateRenewal", "error", err)
-        return fatalIssue(ctx, "proof of possession verification unhandled error", val)
-    }
+		return fatalIssue(ctx, "proof of possession verification unhandled error", val)
+	}
 }
 
 type ParsedRevokeCertificate = {
@@ -381,75 +394,75 @@ type ParsedRevokeCertificate = {
 }
 
 export const refineRevokeCertificate = async (val: ParsedRevokeCertificate, ctx: z.RefinementCtx): Promise<never> => {
-    try {
-        // check proof of possession fingerprint matches public key
-        if (!val.proof.matches(val.public_key)) {
-            return fatalIssue(ctx, "proof of possession fingerprint did not match public_key", val)
-        }
+	try {
+		// check proof of possession fingerprint matches public key
+		if (!val.proof.matches(val.public_key)) {
+			return fatalIssue(ctx, "proof of possession fingerprint did not match public_key", val)
+		}
 
-        // verify proof of possession signature
-        const verified = await val.proof.verify()
-        if (!verified) {
-            return fatalIssue(ctx, "proof of possession signature validation failed", val)
-        }
+		// verify proof of possession signature
+		const verified = await val.proof.verify()
+		if (!verified) {
+			return fatalIssue(ctx, "proof of possession signature validation failed", val)
+		}
 
-        return z.NEVER
-    } catch (err) {
+		return z.NEVER
+	} catch (err) {
 		logger.error("proof of possession verification unhandled error", "in", "refineRevokeCertificate", "error", err)
-        return fatalIssue(ctx, "proof of possession verification unhandled error", val)
-    }
+		return fatalIssue(ctx, "proof of possession verification unhandled error", val)
+	}
 }
 
 type LegacyParsedHostCertificateRenewal = {
-    certificate: Certificate
-    nonce: ProofOfPossession
+	certificate: Certificate
+	nonce: ProofOfPossession
 } & HostCertificateRequest
 
 export const refineLegacyHostCertificateRenewal = async (val: LegacyParsedHostCertificateRenewal, ctx: z.RefinementCtx): Promise<never> => {
-    try {
-        // check certificate is not expired
-        if (val.certificate.isExpired()) {
-            return fatalIssue(ctx, "certificate is expired", val)
-        }
+	try {
+		// check certificate is not expired
+		if (val.certificate.isExpired()) {
+			return fatalIssue(ctx, "certificate is expired", val)
+		}
 
-        // check proof of possession fingerprint matches public key and certificate subject key
-        if (!val.nonce.matches(val.public_key, val.certificate.subjectKey)) {
-            return fatalIssue(ctx, "proof of possession fingerprints did not match public_key and/or certificate", val)
-        }
+		// check proof of possession fingerprint matches public key and certificate subject key
+		if (!val.nonce.matches(val.public_key, val.certificate.subjectKey)) {
+			return fatalIssue(ctx, "proof of possession fingerprints did not match public_key and/or certificate", val)
+		}
 
-        // verify proof of possession signature
-        const verified = await val.nonce.verify("file")
-        if (!verified) {
-            return fatalIssue(ctx, "proof of possession signature validation failed", val)
-        }
+		// verify proof of possession signature
+		const verified = await val.nonce.verify("file")
+		if (!verified) {
+			return fatalIssue(ctx, "proof of possession signature validation failed", val)
+		}
 
-        return z.NEVER
-    } catch (err) {
-        return fatalIssue(ctx, "proof of possession verification unhandled error", val)
-    }
+		return z.NEVER
+	} catch (err) {
+		return fatalIssue(ctx, "proof of possession verification unhandled error", val)
+	}
 }
 
 export const split = (v: string): string[] => {
-    if (v === "" || v === undefined) {
-        return []
-    }
+	if (v === "" || v === undefined) {
+		return []
+	}
 
-    return v.split(",")
+	return v.split(",")
 }
 
-export const getPublic = async (key?: PrivateKey) => {
-    if (key === undefined) {
-        // grab private key from secret store
-        const secret = await env.PRIVATE_KEY.get()
+export const getPublic = async (key?: PrivateKey): Promise<Key> => {
+	if (key === undefined) {
+		// grab private key from secret store
+		const secret = await env.PRIVATE_KEY.get()
 
-        // parse it
-        key = parsePrivateKey(secret)
-    }
+		// parse it
+		key = parsePrivateKey(secret)
+	}
 
-    // convert to a public key and add comment
-    const pub = key.toPublic()
-    pub.comment = env.ISSUER_DN
+	// convert to a public key and add comment
+	const pub = key.toPublic()
+	pub.comment = env.ISSUER_DN
 
-    // return in ssh format trimmed of any whitespace
-    return pub.toString("ssh").trim()
+	// return in ssh format trimmed of any whitespace
+	return pub
 }

--- a/test/certificate.test.ts
+++ b/test/certificate.test.ts
@@ -2,7 +2,7 @@ import { privateKey as rsaPrivateKey, userPrivateKey as userRsaPrivateKey } from
 import { privateKey as ecdsaPrivateKey, userPrivateKey as userEcdsaPrivateKey } from "./keys/ecdsa"
 import { privateKey as ed25519PrivateKey, userPrivateKey as userEd25519PrivateKey } from "./keys/ed25519"
 import { describe, expect, it } from "vitest"
-import { generateCertificate } from "../src/certificate"
+import { generateCertificate, generateSerial } from "../src/certificate"
 import { seconds } from "itty-time"
 import { split } from "../src/utils"
 import { env } from "cloudflare:workers"
@@ -23,7 +23,7 @@ type Tests = {
     name: string
     email: string
     useridenties: string[]
-    now: number
+    serial: bigint
     caKey: PrivateKey
     wantErr?: string
 }
@@ -37,7 +37,7 @@ const tests: Tests[] = [
             "group1",
             "group2",
         ],
-        now: Date.now(),
+        serial: generateSerial().readBigUInt64BE(0),
         caKey: rsaCAKey,
         wantErr: "Failed to parse private key"
     },
@@ -49,7 +49,7 @@ const tests: Tests[] = [
             "group1",
             "group2",
         ],
-        now: Date.now(),
+        serial: generateSerial().readBigUInt64BE(0),
         caKey: ecdsaCAKey,
     },
     {
@@ -60,7 +60,7 @@ const tests: Tests[] = [
             "group1",
             "group2",
         ],
-        now: Date.now(),
+        serial: generateSerial().readBigUInt64BE(0),
         caKey: ed25519CAKey,
     },
 ]
@@ -69,7 +69,7 @@ for (const tt of tests) {
     describe(`generateCertificate (${tt.name})`, async () => {
         if (tt.wantErr === undefined) {
             it("handle RSA user key", () => {
-                const certificate = generateCertificate(tt.email, tt.caKey, userRsaKey.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, now: now })
+                const certificate = generateCertificate(tt.email, tt.caKey, userRsaKey.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, serial: tt.serial })
 
                 // check its signed by the CA
                 expect(certificate.isSignedByKey(tt.caKey.toPublic())).toBe(true)
@@ -94,7 +94,7 @@ for (const tt of tests) {
 
                 // confirm serial is set as expected
                 const serialValue = certificate.serial.readBigUInt64BE(0)
-                expect(serialValue).toBe(BigInt(now))
+                expect(serialValue).toBe(tt.serial)
 
                 // confirm lifetime
                 const lifetime = Math.round((certificate.validUntil.getTime() - certificate.validFrom.getTime()) / 1000)
@@ -102,7 +102,7 @@ for (const tt of tests) {
             })
 
             it("handle ECDSA user key", () => {
-                const certificate = generateCertificate(tt.email, tt.caKey, userEcdsaKey.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, now: now })
+                const certificate = generateCertificate(tt.email, tt.caKey, userEcdsaKey.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, serial: tt.serial })
 
                 // check its signed by the CA
                 expect(certificate.isSignedByKey(tt.caKey.toPublic())).toBe(true)
@@ -127,7 +127,7 @@ for (const tt of tests) {
 
                 // confirm serial is set as expected
                 const serialValue = certificate.serial.readBigUInt64BE(0)
-                expect(serialValue).toBe(BigInt(now))
+                expect(serialValue).toBe(tt.serial)
 
                 // confirm lifetime
                 const lifetime = Math.round((certificate.validUntil.getTime() - certificate.validFrom.getTime()) / 1000)
@@ -135,9 +135,9 @@ for (const tt of tests) {
             })
 
             it("handle ED25519 user key", () => {
-                const certificate = generateCertificate(tt.email, tt.caKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, now: now })
+                const certificate = generateCertificate(tt.email, tt.caKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, serial: tt.serial })
 
-                // check its signed by the CA 
+                // check its signed by the CA
                 expect(certificate.isSignedByKey(tt.caKey.toPublic())).toBe(true)
 
                 // check subjects
@@ -160,7 +160,7 @@ for (const tt of tests) {
 
                 // confirm serial is set as expected
                 const serialValue = certificate.serial.readBigUInt64BE(0)
-                expect(serialValue).toBe(BigInt(now))
+                expect(serialValue).toBe(tt.serial)
 
                 // confirm lifetime
                 const lifetime = Math.round((certificate.validUntil.getTime() - certificate.validFrom.getTime()) / 1000)
@@ -168,7 +168,7 @@ for (const tt of tests) {
             })
 
             it("user key with less extensions", () => {
-                const certificate = generateCertificate(tt.email, tt.caKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, extensions: ["permit-user-rc"], now: now })
+                const certificate = generateCertificate(tt.email, tt.caKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, extensions: ["permit-user-rc"], serial: tt.serial})
 
                 // check its signed by the CA
                 expect(certificate.isSignedByKey(tt.caKey.toPublic())).toBe(true)
@@ -193,7 +193,7 @@ for (const tt of tests) {
 
                 // confirm serial is set as expected
                 const serialValue = certificate.serial.readBigUInt64BE(0)
-                expect(serialValue).toBe(BigInt(now))
+                expect(serialValue).toBe(tt.serial)
 
                 // confirm lifetime
                 const lifetime = Math.round((certificate.validUntil.getTime() - certificate.validFrom.getTime()) / 1000)
@@ -201,32 +201,32 @@ for (const tt of tests) {
             })
 
             it("user key with extra extensions", () => {
-                expect(() => generateCertificate(tt.email, tt.caKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, extensions: ["no-touch-required"], now: now }))
+                expect(() => generateCertificate(tt.email, tt.caKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, extensions: ["no-touch-required"], serial: tt.serial }))
                     .toThrow("no-touch-required is not allowed")
             })
         } else {
             it("handle RSA user key", () => {
-                expect(() => generateCertificate(tt.email, rsaCAKey, userRsaKey.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, now: now }))
+                expect(() => generateCertificate(tt.email, rsaCAKey, userRsaKey.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, serial: tt.serial }))
                     .toThrow("Failed to parse private key")
             })
 
             it("handle ECDSA user key", () => {
-                expect(() => generateCertificate(tt.email, rsaCAKey, userEcdsaKey.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, now: now }))
+                expect(() => generateCertificate(tt.email, rsaCAKey, userEcdsaKey.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, serial: tt.serial }))
                     .toThrow("Failed to parse private key")
             })
 
             it("handle ED25519 user key", () => {
-                expect(() => generateCertificate(tt.email, rsaCAKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, now: now }))
+                expect(() => generateCertificate(tt.email, rsaCAKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, serial: tt.serial }))
                     .toThrow("Failed to parse private key")
             })
 
             it("user key with less extensions", () => {
-                expect(() => generateCertificate(tt.email, rsaCAKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, extensions: ["permit-user-rc"], now: now }))
+                expect(() => generateCertificate(tt.email, rsaCAKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, extensions: ["permit-user-rc"], serial: tt.serial }))
                     .toThrow("Failed to parse private key")
             })
 
             it("user key with extra extensions", () => {
-                expect(() => generateCertificate(tt.email, rsaCAKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, extensions: ["no-touch-required"], now: now }))
+                expect(() => generateCertificate(tt.email, rsaCAKey, userEd25519Key.toPublic(), { lifetime: seconds(lifetimeString), principals: tt.useridenties, extensions: ["no-touch-required"], serial: tt.serial }))
                     .toThrow("Failed to parse private key")
             })
         }


### PR DESCRIPTION
This PR fixes a few issues as follows:
* add missing CA check for host cert renewals
* handling id token verification as part of the request verification code (ie in a transform)
* fix a mismatch in the README for `SSH_CERTIFICATE_INCLUDE_SELF`
* change the default for `SSH_CERTIFICATE_INCLUDE_SELF` to be blank
* don't return internal error messages as `InternalServerErrorException`'s
* lots of whitespace from a few code formatting runs